### PR TITLE
Remove os.system call for streamlit

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -1,3 +1,4 @@
+# This app should be launched with `streamlit run valmet_app.py`
 import streamlit as st
 import os
 import sys
@@ -171,7 +172,3 @@ st.markdown(
     - **Tablas Resumen:** Estadísticas clave (media, mediana, min, max, P5, P95, desviación estándar, cantidad de datos válidos) por variable.
     """
 )
-# --- Bloque principal para ejecución local o desde Render ---
-if __name__ == "__main__":
-    import os
-    os.system("streamlit run valmet_app.py")


### PR DESCRIPTION
## Summary
- add a note that the file should be executed using `streamlit run`
- remove the `os.system` call that started Streamlit from inside `valmet_app.py`

## Testing
- `python -m py_compile valmet_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687feb85c094832b8738a347d9b197bd