### PR TITLE
Fix HTML body tag typo

### DIFF
--- a/valmet_analisis.py
+++ b/valmet_analisis.py
@@ -413,7 +413,7 @@ def generate_summary_table(df, output_dir, project_title):
             <head>
                 <title>Resumen de Análisis - {project_title}</title>
                 <style>
-                    bbody { font-family: sans-serif; color: white; background-color: #2F2740; }
+                    body { font-family: sans-serif; color: white; background-color: #2F2740; }
                     h2 {{ color: #2F2740; }}
                     table {{ width: 100%; border-collapse: collapse; margin-top: 15px; font-size: 0.9em; }}
                     th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}


### PR DESCRIPTION
## Summary
- fix typo `bbody` to `body` in HTML template

## Testing
- `grep -n bbody valmet_analisis.py`

------
https://chatgpt.com/codex/tasks/task_e_687feb80792c832b884c0384044ed195