### PR TITLE
Fix run_analysis exception handling

### DIFF
--- a/valmet_analisis.py
+++ b/valmet_analisis.py
@@ -533,5 +533,5 @@ def run_analysis(csv_file_path, output_dir, palette_name, project_title):
     except Exception as e:
         error_msg = f"Ocurrió un error inesperado durante el procesamiento o la generación: {e}. Por favor, revisa el formato de tus datos."
         print(error_msg)
-        return None, None 
+        raise
 


### PR DESCRIPTION
## Summary
- rethrow caught exceptions in `run_analysis` instead of returning `(None, None)`

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68817ec72530832b86ebfe980ceb54b5