### PR TITLE
Display icon in Streamlit UI

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -21,8 +21,12 @@ except ImportError:
 st.set_page_config(
     page_title="VALMET-GUI",
     layout="wide",
-    initial_sidebar_state="expanded"
+    initial_sidebar_state="expanded",
+    page_icon="icon.png"
 )
+
+# Muestra el icono en la propia interfaz
+st.image("icon.png", width=96)
 
 # Paletas de colores disponibles (las mismas que usas)
 PALETTES = [


### PR DESCRIPTION
## Summary
- show icon when setting Streamlit page config
- display the icon within the UI

## Testing
- `pytest -q` *(tests skipped: pandas/seaborn/matplotlib/windrose missing)*

------
https://chatgpt.com/codex/tasks/task_e_68817ffb2780832bb243e84553e45467