### PR TITLE
Fix CSS string formatting in HTML summary

### DIFF
--- a/valmet_analisis.py
+++ b/valmet_analisis.py
@@ -401,7 +401,7 @@ def generate_summary_table(df, output_dir, project_title):
             <head>
                 <title>Resumen de Análisis - {project_title}</title>
                 <style>
-                    body { font-family: sans-serif; color: white; background-color: #2F2740; }
+                    body {{ font-family: sans-serif; color: white; background-color: #2F2740; }}
                     h2 {{ color: white; }}
                     table {{ width: 100%; border-collapse: collapse; margin-top: 15px; font-size: 0.9em; }}
                     th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}


### PR DESCRIPTION
## Summary
- escape curly braces in the `<style>` block of the summary HTML string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688181b60140832bb41ccbb7265e27e5