### PR TITLE
Adjust sidebar icon and table styling

### DIFF
--- a/valmet_analisis.py
+++ b/valmet_analisis.py
@@ -404,7 +404,7 @@ def generate_summary_table(df, output_dir, project_title):
                     body {{ font-family: sans-serif; color: white; background-color: #2F2740; }}
                     h2 {{ color: white; }}
                     table {{ width: 100%; border-collapse: collapse; margin-top: 15px; font-size: 0.9em; }}
-                    th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
+                    th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; color: black; }}
                     th {{ background-color: #f2f2f2; }}
                     .table-striped tbody tr:nth-of-type(odd) {{ background-color: rgba(0,0,0,.05); }}
                 </style>

--- a/valmet_app.py
+++ b/valmet_app.py
@@ -37,7 +37,7 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-st.image("icon.png", width=96)
+
 
 # Paletas de colores disponibles (las mismas que usas)
 PALETTES = [
@@ -60,7 +60,10 @@ st.write(
 
 # --- Controles de Entrada (SideBar) ---
 with st.sidebar:
-    st.image("icon.png", width=80)
+    st.markdown(
+        "<div style='text-align:center'><img src='icon.png' width='80'></div>",
+        unsafe_allow_html=True,
+    )
     st.header("Configuración del Análisis")
     st.markdown(
         """


### PR DESCRIPTION
## Summary
- center the sidebar icon and remove duplicate from main page
- make statistic table headers readable against light background

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688183b1fea8832b8d8c7b5f39326ac7