### PR TITLE
Fix Streamlit icon path

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -9,6 +9,7 @@ from datetime import datetime
 current_dir = os.path.dirname(__file__)
 if current_dir not in sys.path:
     sys.path.append(current_dir)
+icon_path = os.path.join(current_dir, "icon.png")
 
 try:
     from valmet_analisis import run_analysis
@@ -22,7 +23,7 @@ st.set_page_config(
     page_title="VALMET-GUI",
     layout="wide",
     initial_sidebar_state="expanded",
-    page_icon="icon.png"
+    page_icon=icon_path
 )
 
 # Muestra el icono en la propia interfaz
@@ -61,7 +62,7 @@ st.write(
 # --- Controles de Entrada (SideBar) ---
 with st.sidebar:
     st.markdown(
-        "<div style='text-align:center'><img src='icon.png' width='80'></div>",
+        f"<div style='text-align:center'><img src='{icon_path}' width='80'></div>",
         unsafe_allow_html=True,
     )
     st.header("Configuración del Análisis")


### PR DESCRIPTION
## Summary
- ensure the Streamlit icon uses an absolute path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688185308130832bbd77d67b81b6f869