### PR TITLE
Center sidebar icon

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -90,6 +90,11 @@ with st.sidebar:
     st.markdown(
         """
         <style>
+        div[data-testid="stSidebar"] img {
+            display: block;
+            margin-left: auto;
+            margin-right: auto;
+        }
         div[data-testid="stSidebar"] .stButton > button {
             display: block;
             margin-left: auto;


### PR DESCRIPTION
## Summary
- ensure icon is centered in the sidebar by styling sidebar images
- keep sidebar buttons centered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818b328144832b97ffc84a7663f849