### PR TITLE
Apply custom color palette

### DIFF
--- a/valmet_analisis.py
+++ b/valmet_analisis.py
@@ -401,12 +401,12 @@ def generate_summary_table(df, output_dir, project_title):
             <head>
                 <title>Resumen de Análisis - {project_title}</title>
                 <style>
-                    body {{ font-family: sans-serif; color: white; background-color: #2F2740; }}
-                    h2 {{ color: white; }}
+                    body {{ font-family: sans-serif; color: #D9CDBF; background-color: #2F2740; }}
+                    h2 {{ color: #A6998F; }}
                     table {{ width: 100%; border-collapse: collapse; margin-top: 15px; font-size: 0.9em; }}
-                    th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; color: black; }}
-                    th {{ background-color: #f2f2f2; }}
-                    .table-striped tbody tr:nth-of-type(odd) {{ background-color: rgba(0,0,0,.05); }}
+                    th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; color: #140D40; }}
+                    th {{ background-color: #594C3C; color: #D9CDBF; }}
+                    .table-striped tbody tr:nth-of-type(odd) {{ background-color: rgba(166,153,143,0.2); }}
                 </style>
             </head>
             <body>

--- a/valmet_app.py
+++ b/valmet_app.py
@@ -26,6 +26,37 @@ st.set_page_config(
     page_icon=icon_path
 )
 
+# Colores de la interfaz
+BACKGROUND_COLOR = "#2F2740"
+SIDEBAR_COLOR = "#140D40"
+TEXT_COLOR = "#D9CDBF"
+BUTTON_COLOR = "#594C3C"
+ACCENT_COLOR = "#A6998F"
+
+# Estilos personalizados para aplicar la paleta corporativa
+st.markdown(
+    f"""
+    <style>
+        .stApp {{
+            background-color: {BACKGROUND_COLOR};
+            color: {TEXT_COLOR};
+        }}
+        div[data-testid="stSidebar"] {{
+            background-color: {SIDEBAR_COLOR};
+            color: {TEXT_COLOR};
+        }}
+        div[data-testid="stSidebar"] .stButton>button {{
+            background-color: {BUTTON_COLOR};
+            color: {TEXT_COLOR};
+        }}
+        h1, h2, h3, h4, h5, h6 {{
+            color: {ACCENT_COLOR};
+        }}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 # Muestra el icono en la propia interfaz
 #
 # Paletas de colores disponibles (las mismas que usas)
@@ -198,7 +229,10 @@ elif st.session_state.analysis_error:
     st.error(st.session_state.analysis_error)
 else:
     # Mensaje inicial si no se ha ejecutado el análisis
-    st.info("Presiona 'Generar Análisis' en la barra lateral para comenzar. ➡️")
+    st.markdown(
+        f"<p style='color:{TEXT_COLOR};'>Presiona 'Generar Análisis' en la barra lateral para comenzar. ➡️</p>",
+        unsafe_allow_html=True,
+    )
 
 with st.expander("Tipos de Gráficos y Reportes Generados"):
     st.markdown(


### PR DESCRIPTION
## Summary
- style GUI using the requested color palette
- update summary report CSS for the same palette
- style start message with a lighter color

## Testing
- `pytest -q` *(fails: 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68818e797a9c832bbb060f0ae63cc529