### PR TITLE
Update palette dropdown text color

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -49,6 +49,10 @@ st.markdown(
             background-color: {BUTTON_COLOR};
             color: {TEXT_COLOR};
         }}
+        div[data-testid="stSidebar"] select,
+        div[data-testid="stSidebar"] select option {{
+            color: {SIDEBAR_COLOR};
+        }}
         h1, h2, h3, h4, h5, h6 {{
             color: {ACCENT_COLOR};
         }}


### PR DESCRIPTION
## Summary
- darken palette dropdown text so palette names display in dark color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881943690f4832b8a5f9adeb6d9ed89