### PR TITLE
Update input widget colors

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -52,6 +52,15 @@ st.markdown(
         h1, h2, h3, h4, h5, h6 {{
             color: {ACCENT_COLOR};
         }}
+        /* Input and file uploader colors */
+        div[data-testid="stTextInput"] input {
+            background-color: {ACCENT_COLOR};
+            color: {SIDEBAR_COLOR};
+        }
+        div[data-testid="stFileUploader"] section label {
+            background-color: {ACCENT_COLOR};
+            color: {SIDEBAR_COLOR};
+        }
     </style>
     """,
     unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- update text input and file uploader colors to corporate palette

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688194968278832b80eb4577c1380484