### PR TITLE
Enable dark mode

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,7 @@
 [theme]
-base="light"
-primaryColor="#4CAF50"
-backgroundColor="#F7F7F7"
+base="dark"
+primaryColor="#594C3C"
+backgroundColor="#2F2740"
 secondaryBackgroundColor="#140D40"
 textColor="#D9CDBF"
 font="sans serif"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Lanza la interfaz de Streamlit con:
 streamlit run valmet_app.py
 ```
 
+La interfaz utiliza un tema oscuro personalizado. Si deseas cambiarlo puedes
+editar los colores en `.streamlit/config.toml`.
+
 ## Pruebas
 
 Para ejecutar las pruebas automatizadas utiliza:


### PR DESCRIPTION
## Summary
- enable dark mode theme via `.streamlit/config.toml`
- mention dark mode in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a2d01fb4832b8fde68f46f85c8f7