### PR TITLE
Fix CSS braces to prevent NameError

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -57,14 +57,14 @@ st.markdown(
             color: {ACCENT_COLOR};
         }}
         /* Input and file uploader colors */
-        div[data-testid="stTextInput"] input {
+        div[data-testid="stTextInput"] input {{
             background-color: {ACCENT_COLOR};
             color: {SIDEBAR_COLOR};
-        }
-        div[data-testid="stFileUploader"] section label {
+        }}
+        div[data-testid="stFileUploader"] section label {{
             background-color: {ACCENT_COLOR};
             color: {SIDEBAR_COLOR};
-        }
+        }}
     </style>
     """,
     unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- correct braces in st.markdown CSS blocks to avoid NameError during runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825a319278832bbfb67fa518d20be3