### PR TITLE
Add requirements-dev file and update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,9 @@ editar los colores en `.streamlit/config.toml`.
 Para ejecutar las pruebas automatizadas utiliza:
 
 ```bash
+pip install -r requirements.txt -r requirements-dev.txt
+```
+
+```bash
 pytest tests/test_run_analysis.py
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest
+pandas
+numpy
+matplotlib
+seaborn
+windrose


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` with dependencies needed for testing
- mention installing these dev requirements before running tests in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882611ae560832b8e9c3c6aeb6b1540