### PR TITLE
Update packaging notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ pytest tests/test_run_analysis.py
 ## Empaquetado
 
 Para distribuir la aplicación como un ejecutable independiente puedes usar
-PyInstaller.
+PyInstaller. Ejecuta PyInstaller desde un entorno en el que tengas
+`streamlit` instalado y añade la opción `--hidden-import=streamlit.web.cli`
+para evitar el error `PackageNotFoundError`.
 
 1. Instala PyInstaller:
 
@@ -47,11 +49,17 @@ pip install pyinstaller
 
 2. Genera el ejecutable con:
 
+El parámetro `--add-data` utiliza `;` como separador en Windows y `:` en
+macOS/Linux.
+
 ```bash
-pyinstaller --onefile --add-data "icon.png;." main.py
+pyinstaller --onefile --add-data "icon.png;." --hidden-import=streamlit.web.cli main.py
 ```
 
-3. El archivo resultante se encuentra en `dist/main.exe`.
+En macOS/Linux sustituye `;` por `:` en el argumento `--add-data`.
 
-PyInstaller empaqueta todas las dependencias, por lo que quien reciba
-`main.exe` no necesitará tener Python instalado para ejecutarlo.
+3. El archivo resultante se encuentra en `dist/main.exe` en Windows y en
+`dist/main` en sistemas Unix.
+
+PyInstaller empaqueta todas las dependencias, por lo que quien reciba el
+ejecutable no necesitará tener Python instalado para ejecutarlo.


### PR DESCRIPTION
## Summary
- clarify PyInstaller instructions
- note platform-specific separator
- mention output file name without `.exe` on Unix
- recommend using a Streamlit environment with hidden-import

## Testing
- `pytest tests/test_run_analysis.py` *(fails: collected 0 items / 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688276bf5b88832ba3956aa299aa41f7