### PR TITLE
Add developer LinkedIn link in GUI

### DIFF
--- a/valmet_app.py
+++ b/valmet_app.py
@@ -158,6 +158,10 @@ with st.sidebar:
 
     run_button = st.button("🚀 Generar Análisis")
 
+    st.markdown(
+        "Desarrollado por [José Chávez Pérez](https://www.linkedin.com/in/jose-chavez-perez/)"
+    )
+
 # --- Lógica del Botón y Salida ---
 # Usamos un estado de sesión para mostrar los resultados solo después de que se generen
 if 'analysis_run_completed' not in st.session_state:


### PR DESCRIPTION
## Summary
- add credit to José Chávez Pérez with a LinkedIn link in the sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885156f2c70832b95d17e5d96126532